### PR TITLE
Detect the version and bitness of LabVIEW to use for LVCompare and LVMerge

### DIFF
--- a/bin/LVBootstrap.sh
+++ b/bin/LVBootstrap.sh
@@ -2,12 +2,12 @@
 
 OPT=$(echo $1 | tr "[:upper:]" "[:lower:]")
 REPO_ROOT="$(pwd)"
-REPO_ATTR=$(cat "$REPO_ROOT/etc/LVGitAttributes.tpl")
+REPO_ATTR=$(cat "${REPO_ROOT}/etc/LVGitAttributes.tpl")
 
-source "$REPO_ROOT/etc/LVUtilities.sh"
+source "${REPO_ROOT}/etc/LVUtilities.sh"
 
-handle_options "$OPT"
-install_drivers "$REPO_ROOT"
-update_attributes "$REPO_ATTR"
-do_git_config "git config $GIT_CONFIG_OPTS"
+handle_options "${OPT}"
+install_drivers "${REPO_ROOT}"
+update_attributes "${REPO_ATTR}"
+do_git_config "git config ${GIT_CONFIG_OPTS}"
 

--- a/bin/LVBootstrap.sh
+++ b/bin/LVBootstrap.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+OPT=$(echo $1 | tr "[:upper:]" "[:lower:]")
+REPO_ROOT="$(pwd)"
+REPO_ATTR=$(cat "$REPO_ROOT/etc/LVGitAttributes.tpl")
+
+source "$REPO_ROOT/etc/LVUtilities.sh"
+
+handle_options "$OPT"
+install_drivers "$REPO_ROOT"
+update_attributes "$REPO_ATTR"
+do_git_config "git config $GIT_CONFIG_OPTS"
+

--- a/bin/LVCompareWrapper.sh
+++ b/bin/LVCompareWrapper.sh
@@ -20,8 +20,13 @@ LOCAL=$(echo "$2" | sed -e "${PATHFIX}")
 REMOTE=$(echo "$5" | sed -e  "${PATHFIX}")
 
 # Check if absolute path and complete with working directory if not
-echo "$LOCAL" | grep -qE $ABSPATH || LOCAL="${WD}\\${LOCAL}"
-echo "$REMOTE" | grep -qE $ABSPATH || REMOTE="${WD}\\${REMOTE}"
+echo "${LOCAL}" | grep -qE ${ABSPATH} || LOCAL="${WD}\\${LOCAL}"
+echo "${REMOTE}" | grep -qE ${ABSPATH} || REMOTE="${WD}\\${REMOTE}"
+
+if type detect_labview_version &> /dev/null; then
+	detect_labview_version "${LOCAL}"
+	fix_paths
+fi
 
 # Execute Compare
 "${LabViewShared}/LabVIEW Compare/LVCompare.exe" "${LOCAL}" "${REMOTE}" "-lvpath" "${LabViewBin}"

--- a/bin/LVCompareWrapper.sh
+++ b/bin/LVCompareWrapper.sh
@@ -23,10 +23,7 @@ REMOTE=$(echo "$5" | sed -e  "${PATHFIX}")
 echo "${LOCAL}" | grep -qE ${ABSPATH} || LOCAL="${WD}\\${LOCAL}"
 echo "${REMOTE}" | grep -qE ${ABSPATH} || REMOTE="${WD}\\${REMOTE}"
 
-if type detect_labview_version &> /dev/null; then
-	detect_labview_version "${LOCAL}"
-	fix_paths
-fi
-
 # Execute Compare
+detect_labview_version "${LOCAL}"
+fix_paths
 "${LabViewShared}/LabVIEW Compare/LVCompare.exe" "${LOCAL}" "${REMOTE}" "-lvpath" "${LabViewBin}"

--- a/bin/LVInit.sh
+++ b/bin/LVInit.sh
@@ -5,7 +5,7 @@ GIT_ATTR=$(cat ~/etc/LVGitAttributes.tpl 2>/dev/null || cat /usr/local/etc/LVGit
 
 source ~/etc/LVUtilities.sh 2>/dev/null || source /usr/local/etc/LVUtilities.sh 2>/dev/null
 
-handle_options "$OPT"
-update_attributes "$GIT_ATTR"
+handle_options "${OPT}"
+update_attributes "${GIT_ATTR}"
 do_git_config "git config ${GIT_CONFIG_OPTS}"
 

--- a/bin/LVInit.sh
+++ b/bin/LVInit.sh
@@ -1,53 +1,11 @@
 #!/bin/bash
 
 OPT=$(echo $1 | tr "[:upper:]" "[:lower:]")
+GIT_ATTR=$(cat ~/etc/LVGitAttributes.tpl 2>/dev/null || cat /usr/local/etc/LVGitAttributes.tpl 2>/dev/null)
 
-function do_git_config {
-	$1 diff.labview.command "LVCompareWrapper.sh"
-	$1 diff.labview.tool labview
-	$1 diff.labview.guitool labview
-	$1 difftool.labview.cmd "LVCompareWrapper.sh \"\$LOCAL\" \"\$REMOTE\""
-	$1 difftool.labview.prompt false
-	$1 merge.labview.tool labview
-	$1 merge.labview.name "LabView Merge Driver"
-	$1 merge.labview.driver "LVMergeWrapper.sh \"%O\" \"%B\" \"%A\""
-	$1 mergetool.labview.cmd "LVMergeWrapper.sh \"\$BASE\" \"\$REMOTE\" \"\$LOCAL\""
-	$1 mergetool.labview.trustExitCode true
-	if [ $OPT == "--global" ]
-	then
-		$1 core.attributesfile $ATTRIBUTES_FILE
-	fi
-}
+source ~/etc/LVUtilities.sh 2>/dev/null || source /usr/local/etc/LVUtilities.sh 2>/dev/null
 
-case "$OPT" in
-	--system)
-		GIT_CONFIG_OPTS="--system"
-		ATTRIBUTES_FILE=/etc/gitattributes
-	;;
-	--global)
-		GIT_CONFIG_OPTS="--global"
-		ATTRIBUTES_FILE=~/.gitattributes
-	;;
-	--local)
-		git status &> /dev/null || { echo "You are not in a GIT Repository"; exit 0; }
-		GIT_CONFIG_OPTS="--local"
-		ATTRIBUTES_FILE=.git/info/attributes
-	;;
-	*) 
-		echo -e "Usage: \"$0 option\" where option can be one of the following
---system - This will try to do a system wide configuration
---global - This will try to do a user configuration
---local - This will try to configure the local repository
-anything else will print this text"
-		exit 0;
-esac
-
-# Set git config
+handle_options "$OPT"
+update_attributes "$GIT_ATTR"
 do_git_config "git config ${GIT_CONFIG_OPTS}"
 
-# Create attributes file if missing and write specifics
-ATTRIBUTES_FILE_ABSOLUTE=$(echo ${ATTRIBUTES_FILE})
-touch ${ATTRIBUTES_FILE_ABSOLUTE}
-
-CONT=$(cat ~/etc/LVGitAttributes.tpl 2>/dev/null || cat /usr/local/etc/LVGitAttributes.tpl 2>/dev/null)
-grep -q "${CONT}" ${ATTRIBUTES_FILE_ABSOLUTE} || echo "${CONT}" >> ${ATTRIBUTES_FILE_ABSOLUTE}

--- a/bin/LVMergeWrapper.sh
+++ b/bin/LVMergeWrapper.sh
@@ -21,12 +21,9 @@ LOCAL="${WD}\\$(echo "$2" | sed -e "${TRAILFIX}")"
 REMOTE="${WD}\\$(echo "$3" | sed -e  "${TRAILFIX}")"
 MERGED=${REMOTE}
 
-if type detect_labview_version &> /dev/null; then
-	detect_labview_version "${BASE}"
-	fix_paths
-fi
-
 # Execute Compare
+detect_labview_version "${BASE}"
+fix_paths
 "${LabViewShared}/LabVIEW Merge/LVMerge.exe" "${LabViewBin}" "${BASE}" "${REMOTE}" "${LOCAL}" "${MERGED}"
 
 for i in {0..99}; do

--- a/bin/LVMergeWrapper.sh
+++ b/bin/LVMergeWrapper.sh
@@ -19,7 +19,12 @@ fi
 BASE="${WD}\\$(echo "$1" | sed -e "${TRAILFIX}")"
 LOCAL="${WD}\\$(echo "$2" | sed -e "${TRAILFIX}")"
 REMOTE="${WD}\\$(echo "$3" | sed -e  "${TRAILFIX}")"
-MERGED=$REMOTE
+MERGED=${REMOTE}
+
+if type detect_labview_version &> /dev/null; then
+	detect_labview_version "${BASE}"
+	fix_paths
+fi
 
 # Execute Compare
 "${LabViewShared}/LabVIEW Merge/LVMerge.exe" "${LabViewBin}" "${BASE}" "${REMOTE}" "${LOCAL}" "${MERGED}"
@@ -34,7 +39,7 @@ for i in {0..99}; do
 done
 
 echo "It seems you either can't type or you are using gitk. For the latter "
-echo "one I have no means of knowing wether the merge succeeded or not, "
+echo "one I have no means of knowing whether the merge succeeded or not, "
 echo "so I have to stop the merge and you have to commit it manually."
 
 exit 255

--- a/etc/LVConfig.sh
+++ b/etc/LVConfig.sh
@@ -19,7 +19,22 @@ MKWINPATH='s/^\/\([a-z]\)/\U\1:/'
 # Check if Path is abolsute: if either ^/@/ or ^@:\ where @ is the drive letter
 ABSPATH='^([a-zA-Z]:\\|/[a-zA-Z]/)'
 
-# Repository directory in windows path notation
-WD=$(pwd | sed -e "${ENDFIX}" | sed -e "${MKWINPATH}" | sed -e  "${PATHFIX}")
-# LVCompare.exe needs this path in Windows format
-LabViewBin=$(echo $LabViewBin | sed -e "${MKWINPATH}" | sed -e "${PATHFIX}")
+# Attempt to detect the LabVIEW version
+for basePath in '/usr/local/etc' '~/etc' '.'; do
+	candidateFile="${basePath}/LVDetect.sh"
+	if [ -r "${candidateFile}" ]; then
+		source ${candidateFile}
+		break
+	fi
+done
+
+function fix_paths {
+	# Repository directory in windows path notation
+	WD=$(pwd | sed -e "${ENDFIX}" | sed -e "${MKWINPATH}" | sed -e  "${PATHFIX}")
+
+	# LVCompare.exe needs this path in Windows format
+	LabViewBin=$(echo ${LabViewBin} | sed -e "${MKWINPATH}" | sed -e "${PATHFIX}")
+}
+
+fix_paths
+

--- a/etc/LVDetect.sh
+++ b/etc/LVDetect.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Return the year-based LabVIEW release associated with the file version in $1
+function year_for_file_version {
+	case "$1" in
+		9.0)
+			echo 2009
+		;;
+		10.0)
+			echo 2010
+		;;
+		11.0)
+			echo 2011
+		;;
+		12.0)
+			echo 2012
+		;;
+		13.0)
+			echo 2013
+		;;
+		14.0)
+			echo 2014
+		;;
+		*)
+			echo >&2 "ERROR: Unknown LabVIEW file version: $1";
+			exit 0;
+		;;
+	esac
+}
+
+# Set LabViewBin to match or exceed the version used for VI in $1
+function detect_labview_version {
+	VIQueryVersion=VIQueryVersion
+	CanDetectLV=$(hash ${VIQueryVersion} 2>/dev/null)
+
+	if [ -n ${CanDetectLV} ]; then
+		LVFileVersion="$(${VIQueryVersion} $(echo $1 | sed -e "${MKWINPATH}" | sed -e "${PATHFIX}"))"
+		MinLVVersion=$(year_for_file_version ${LVFileVersion})
+
+		for lvVersion in 2009 2010 2011 2012 2013 2014; do
+			if [ -x "/c/Program Files/National Instruments/LabVIEW ${lvVersion}/LabVIEW.exe" ]; then
+				LabViewBin="/c/Program Files/National Instruments/LabVIEW ${lvVersion}/LabVIEW.exe"
+				LabViewShared="/c/Program Files/National Instruments/Shared"
+				Is32BitLVOn64BitWindows=false
+			elif [ -x "/c/Program Files (x86)/National Instruments/LabVIEW ${lvVersion}/LabVIEW.exe" ]; then
+				LabViewBin="/c/Program Files (x86)/National Instruments/LabVIEW ${lvVersion}/LabVIEW.exe"
+				LabViewShared="/c/Program Files (x86)/National Instruments/Shared"
+				Is32BitLVOn64BitWindows=:
+			fi
+
+			if [ ${lvVersion} -ge ${MinLVVersion} ]; then
+				break
+			fi
+		done
+	else
+		echo >&2 "INFO: I could detect the version of LabVIEW to use if VIKit were installed."
+		echo >&2 "INFO: Using \"${LabViewBin}\" by default"
+	fi
+}
+

--- a/etc/LVUtilities.sh
+++ b/etc/LVUtilities.sh
@@ -33,13 +33,14 @@ anything else will print this text"
 function install_drivers {
 	REPO_ROOT_ABSOLUTE="$(echo $1)"
 	ENV_ROOT_ABSOLUTE="$(echo ${ENV_ROOT})"
-	mkdir -p "$ENV_ROOT_ABSOLUTE/bin" "$ENV_ROOT_ABSOLUTE/etc"
+	mkdir -p "${ENV_ROOT_ABSOLUTE}/bin" "${ENV_ROOT_ABSOLUTE}/etc"
 
-	cp "$REPO_ROOT_ABSOLUTE/bin/LVCompareWrapper.sh" "$ENV_ROOT_ABSOLUTE/bin"
-	cp "$REPO_ROOT_ABSOLUTE/bin/LVGitKExternalDiffWrapper.bat" "$ENV_ROOT_ABSOLUTE/bin"
-	cp "$REPO_ROOT_ABSOLUTE/bin/LVMergeWrapper.sh" "$ENV_ROOT_ABSOLUTE/bin"
+	cp "${REPO_ROOT_ABSOLUTE}/bin/LVCompareWrapper.sh" "${ENV_ROOT_ABSOLUTE}/bin"
+	cp "${REPO_ROOT_ABSOLUTE}/bin/LVGitKExternalDiffWrapper.bat" "${ENV_ROOT_ABSOLUTE}/bin"
+	cp "${REPO_ROOT_ABSOLUTE}/bin/LVMergeWrapper.sh" "${ENV_ROOT_ABSOLUTE}/bin"
 
-	cp "$REPO_ROOT_ABSOLUTE/etc/LVConfig.sh" "$ENV_ROOT_ABSOLUTE/etc"
+	cp "${REPO_ROOT_ABSOLUTE}/etc/LVConfig.sh" "${ENV_ROOT_ABSOLUTE}/etc"
+	cp "${REPO_ROOT_ABSOLUTE}/etc/LVDetect.sh" "${ENV_ROOT_ABSOLUTE}/etc"
 }
 
 # Update git attributes stored in $1
@@ -55,16 +56,16 @@ function do_git_config {
 	$1 diff.labview.command "LVCompareWrapper.sh"
 	$1 diff.labview.tool labview
 	$1 diff.labview.guitool labview
-	$1 difftool.labview.cmd "LVCompareWrapper.sh \"\$LOCAL\" \"\$REMOTE\""
+	$1 difftool.labview.cmd "LVCompareWrapper.sh \"\${LOCAL}\" \"\${REMOTE}\""
 	$1 difftool.labview.prompt false
 	$1 merge.labview.tool labview
 	$1 merge.labview.name "LabView Merge Driver"
 	$1 merge.labview.driver "LVMergeWrapper.sh \"%O\" \"%B\" \"%A\""
-	$1 mergetool.labview.cmd "LVMergeWrapper.sh \"\$BASE\" \"\$REMOTE\" \"\$LOCAL\""
+	$1 mergetool.labview.cmd "LVMergeWrapper.sh \"\${BASE}\" \"\${REMOTE}\" \"\${LOCAL}\""
 	$1 mergetool.labview.trustExitCode true
-	if [ $OPT == "--global" ]
+	if [ ${OPT} == "--global" ]
 	then
-		$1 core.attributesfile "$ATTRIBUTES_FILE"
+		$1 core.attributesfile "${ATTRIBUTES_FILE}"
 	fi
 }
 

--- a/etc/LVUtilities.sh
+++ b/etc/LVUtilities.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Parse command line options in $1
+function handle_options {
+	case "$1" in
+		--system)
+			GIT_CONFIG_OPTS="--system"
+			ATTRIBUTES_FILE=/etc/gitattributes
+			ENV_ROOT=/usr/local
+		;;
+		--global)
+			GIT_CONFIG_OPTS="--global"
+			ATTRIBUTES_FILE=~/.gitattributes
+			ENV_ROOT=~
+		;;
+		--local)
+			git status &> /dev/null || { echo "You are not in a GIT Repository"; exit 0; }
+			GIT_CONFIG_OPTS="--local"
+			ATTRIBUTES_FILE=.git/info/attributes
+			ENV_ROOT=~
+		;;
+		*) 
+			echo -e "Usage: \"$0 option\" where option can be one of the following
+--system - This will try to do a system wide configuration
+--global - This will try to do a user configuration
+--local - This will try to configure the local repository
+anything else will print this text"
+			exit 0;
+	esac
+}
+
+# Install the scripts from directory $1
+function install_drivers {
+	REPO_ROOT_ABSOLUTE="$(echo $1)"
+	ENV_ROOT_ABSOLUTE="$(echo ${ENV_ROOT})"
+	mkdir -p "$ENV_ROOT_ABSOLUTE/bin" "$ENV_ROOT_ABSOLUTE/etc"
+
+	cp "$REPO_ROOT_ABSOLUTE/bin/LVCompareWrapper.sh" "$ENV_ROOT_ABSOLUTE/bin"
+	cp "$REPO_ROOT_ABSOLUTE/bin/LVGitKExternalDiffWrapper.bat" "$ENV_ROOT_ABSOLUTE/bin"
+	cp "$REPO_ROOT_ABSOLUTE/bin/LVMergeWrapper.sh" "$ENV_ROOT_ABSOLUTE/bin"
+
+	cp "$REPO_ROOT_ABSOLUTE/etc/LVConfig.sh" "$ENV_ROOT_ABSOLUTE/etc"
+}
+
+# Update git attributes stored in $1
+function update_attributes {
+	CONT="$1"
+	ATTRIBUTES_FILE_ABSOLUTE="$(echo ${ATTRIBUTES_FILE})"
+	touch "${ATTRIBUTES_FILE_ABSOLUTE}"
+
+	grep -q "${CONT}" "${ATTRIBUTES_FILE_ABSOLUTE}" || echo "${CONT}" >> "${ATTRIBUTES_FILE_ABSOLUTE}"
+}
+
+function do_git_config {
+	$1 diff.labview.command "LVCompareWrapper.sh"
+	$1 diff.labview.tool labview
+	$1 diff.labview.guitool labview
+	$1 difftool.labview.cmd "LVCompareWrapper.sh \"\$LOCAL\" \"\$REMOTE\""
+	$1 difftool.labview.prompt false
+	$1 merge.labview.tool labview
+	$1 merge.labview.name "LabView Merge Driver"
+	$1 merge.labview.driver "LVMergeWrapper.sh \"%O\" \"%B\" \"%A\""
+	$1 mergetool.labview.cmd "LVMergeWrapper.sh \"\$BASE\" \"\$REMOTE\" \"\$LOCAL\""
+	$1 mergetool.labview.trustExitCode true
+	if [ $OPT == "--global" ]
+	then
+		$1 core.attributesfile "$ATTRIBUTES_FILE"
+	fi
+}
+


### PR DESCRIPTION
Hi Jörg,

Your LabViewGitEnv tool is helpful, and I wanted to extend it in two ways:
1. Allow a new user/contributor to install the scripts independently from cloning.
   - Rather than directly clone into `/usr/local`, a contributor might want to clone into a dedicated workspace so that they can control when their changes are propagated to their environment. My proposed change keeps the existing clone-to-install behavior, but also adds an explicit-install script.
2. Detect the version and bitness of LabVIEW to use for LVCompare and LVMerge.
   - Many of the LabViewGitEnv forks update `LVConfig.sh` to match their version and bitness of LabVIEW. My proposed change uses a tool from [VIKit](https://github.com/wireddown/VIKit) to find a matching or newer version of LabVIEW to use. If the tool is not installed, LabViewGitEnv uses the explicit versions in LVConfig.sh.

The first change summarized:
- Move much of the logic in `bin/LVInit.sh` to functions in new file `etc/LVUtilities.sh`.
- Add new file `bin/LVBootstrap.sh`.

The second change summarized:
- Add new file `etc/LVDetect.sh`, which has a function called `detect_labview_version`.
- Source LVDetect.sh in `etc/LVConfig.sh` so the diff and merge wrapper scripts can use it.

Finally, I updated a few words for spelling and changed Bash variable references to ${CurlyBraces}.
