### PR TITLE
Fix testing for the presence of VIKit

### DIFF
--- a/etc/LVDetect.sh
+++ b/etc/LVDetect.sh
@@ -33,7 +33,7 @@ function detect_labview_version {
 	VIQueryVersion=VIQueryVersion
 	CanDetectLV=$(hash ${VIQueryVersion} 2>/dev/null)
 
-	if [ -n ${CanDetectLV} ]; then
+	if [ -n "${CanDetectLV}" ]; then
 		LVFileVersion="$(${VIQueryVersion} $(echo $1 | sed -e "${MKWINPATH}" | sed -e "${PATHFIX}"))"
 		MinLVVersion=$(year_for_file_version ${LVFileVersion})
 

--- a/etc/LVDetect.sh
+++ b/etc/LVDetect.sh
@@ -31,7 +31,7 @@ function year_for_file_version {
 # Set LabViewBin to match or exceed the version used for VI in $1
 function detect_labview_version {
 	VIQueryVersion=VIQueryVersion
-	CanDetectLV=$(hash ${VIQueryVersion} 2>/dev/null)
+	CanDetectLV=$(which ${VIQueryVersion} 2>/dev/null)
 
 	if [ -n "${CanDetectLV}" ]; then
 		LVFileVersion="$(${VIQueryVersion} $(echo $1 | sed -e "${MKWINPATH}" | sed -e "${PATHFIX}"))"


### PR DESCRIPTION
Hi Jörg,

Thanks for merging my pull request :-)

Today I discovered a bug in my changes when I was helping a friend set up your tools. The bug only happens when VIKit is not installed.

Before my fix, this is what would happen:

```
$ git difftool path/to/some.vi
/usr/local/etc/LVDetect.sh: line 37: VIQueryVersion: command not found
ERROR: Unknown LabVIEW file version:
/usr/local/etc/LVDetect.sh: line 51: [: 2009: unary operator expected
/usr/local/etc/LVDetect.sh: line 51: [: 2010: unary operator expected
/usr/local/etc/LVDetect.sh: line 51: [: 2011: unary operator expected
/usr/local/etc/LVDetect.sh: line 51: [: 2012: unary operator expected
/usr/local/etc/LVDetect.sh: line 51: [: 2013: unary operator expected
/usr/local/etc/LVDetect.sh: line 51: [: 2014: unary operator expected
```

After my fix, this is what happens:

```
$ git difftool path/to/some.vi
INFO: I could detect the version of LabVIEW to use if VIKit were installed.
INFO: Using "C:\Program Files\National Instruments\LabVIEW 2009\LabVIEW.exe" by default
```

I'm sorry I didn't test more thoroughly before I made my first pull request :-\

Joe
